### PR TITLE
Create Org: Changes in params

### DIFF
--- a/src/containers/createOrg/index.js
+++ b/src/containers/createOrg/index.js
@@ -351,6 +351,8 @@ class CreateOrg extends React.Component {
       name: orgName,
       sector: sector,
       sectorLevel: entity,
+      parentId: null, // since it is org
+      type: "organization", // since it is org
       address: {
         country: country,
         state: state,


### PR DESCRIPTION
When new org is created parentid is set as null and type is set as organization